### PR TITLE
fix SRT3DTransform.set_mapping()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ __pycache__
 .cache/
 .coverage
 *.egg-info/
+*.swp
 
 

--- a/coorx/__init__.py
+++ b/coorx/__init__.py
@@ -1,5 +1,5 @@
 from .base_transform import BaseTransform, InverseTransform
-from .linear import NullTransform, TTransform, STTransform, AffineTransform, SRT3DTransform
+from .linear import NullTransform, TTransform, STTransform, AffineTransform, SRT3DTransform, RT3DTransform
 from .nonlinear import LogTransform, PolarTransform
 from .composite import CompositeTransform, SimplifiedCompositeTransform
 from .coordinates import Point, PointArray

--- a/coorx/base_transform.py
+++ b/coorx/base_transform.py
@@ -123,6 +123,8 @@ class BaseTransform(object):
         if from_cs is not None:
             cs_graph = CoordinateSystemGraph.get_graph(cs_graph)
             cs_graph.add_transform(self, from_cs=from_cs, to_cs=to_cs)
+        self.from_cs = from_cs
+        self.to_cs = to_cs 
 
     def map(self, obj:Mappable):
         """

--- a/coorx/linear.py
+++ b/coorx/linear.py
@@ -862,10 +862,6 @@ class SRT3DTransform(BaseTransform):
         points2 : ndarray, shape (N, 3)
             Output coordinates.
         """
-        aff = AffineTransform(dims=(3, 3))
-        aff.set_mapping(points1, points2)
-        self.set_from_affine(aff)
-        return
 
         params = self.params
         # params_flat = []

--- a/coorx/linear.py
+++ b/coorx/linear.py
@@ -674,6 +674,228 @@ class SRT2DTransform:
         raise NotImplementedError()
 
 
+class RT3DTransform(BaseTransform):
+    """Transform implemented as 4x4 affine that can always be represented as a combination of 2 matrices: rotate * translate
+    This transform has no shear; angles are always preserved.
+    """
+    def __init__(self, offset=None, angle=None, axis=None, init=None, **kwds):
+        kwds.setdefault('dims', (3, 3))
+        super().__init__(**kwds)
+        assert self.dims == (3, 3), "RT3DTransform can only map 3D coordinates"
+        self._state = {
+            'offset': np.zeros(3),
+            'angle': 0,
+            'axis': np.array([0., 0., 1.])
+        }
+        self._affine = None
+        if all([p is None for p in (offset, angle, axis)]):
+            if init is not None:
+                if isinstance(init, RT3DTransform):
+                    self.set_state(**init._state)
+                elif isinstance(init, SRT2DTransform):
+                    self.set_state(
+                        offset=tuple(init._state['offset']) + (0,),
+                        angle=init._state['angle'],
+                        axis=(0, 0, 1),
+                    )
+                elif isinstance(init, AffineTransform):
+                    self.set_from_affine(init)
+                else:
+                    raise Exception("Cannot build SRTTransform3D from argument type:", type(init))
+        else:
+            assert init is None
+            self.set_params(offset, angle, axis)
+
+    def get_rotation(self):
+        """Return (angle, axis) of rotation"""
+        return self._state['angle'], np.array([self._state['axis']])
+        
+    def get_translation(self):
+        return np.array(self._state['offset'])
+    
+    def reset(self):
+        self._state = {
+            'offset': np.array([0,0,0]),
+            'angle': 0.0,  ## in degrees
+            'axis': (0, 0, 1)
+        }
+        self._update_affine()
+        
+    def translate(self, offset):
+        """Adjust the translation of this transform"""
+        self.set_offset(self._state['offset'] + offset)
+
+    def set_offset(self, offset):
+        """Set the translation of this transform"""
+        self.set_params(offset=offset)
+        
+    def rotate(self, angle, axis):
+        """Adjust the rotation of this transform"""
+        axis = np.asarray(axis)
+        origAxis = self._state['axis']
+        if np.all(axis == origAxis):
+            self.set_rotation(self._state['angle'] + angle)
+        else:
+            m = AffineTransform(dims=self.dims)
+            m.translate(self._state['offset'])
+            m.rotate(self._state['angle'], self._state['axis'])
+            m.rotate(angle, axis)
+            self.set_from_affine(m)
+        
+    def set_rotation(self, angle, axis=(0,0,1)):
+        """Set the transformation rotation to angle (in degrees)"""
+        self.set_params(angle=angle, axis=axis)
+    
+    def set_from_affine(self, tr):
+        """
+        Set this transform based on the elements of *m*
+        The input matrix must be affine AND have no shear,
+        otherwise the conversion will most likely fail.
+        """
+        assert tr.dims == (3, 3)
+
+        m = tr.matrix.T
+
+        # see whether there is an inversion
+        z = np.cross(m[0], m[1])
+        
+        ## rotation axis is the eigenvector with eigenvalue=1
+        r = m 
+        try:
+            evals, evecs = numpy.linalg.eig(r)
+        except Exception:
+            print("Rotation matrix: %s" % str(r))
+            print("Original matrix: %s" % str(m))
+            raise
+        eigIndex = np.argwhere(np.abs(evals-1) < 1e-6)
+        if len(eigIndex) < 1:
+            print("eigenvalues: %s" % str(evals))
+            print("eigenvectors: %s" % str(evecs))
+            print("index: %s, %s" % (str(eigIndex), str(evals-1)))
+            raise Exception("Could not determine rotation axis.")
+        axis = evecs[:,eigIndex[0,0]].real
+        axis /= ((axis**2).sum())**0.5
+        
+        # trace(r) == 2 cos(angle) + 1, so:
+        cos = (r.trace()-1)*0.5  # this only gets us abs(angle)
+        
+        # The off-diagonal values can be used to correct the angle ambiguity, 
+        # but we need to figure out which element to use:
+        axisInd = np.argmax(np.abs(axis))
+        rInd,sign = [((1,2), -1), ((0,2), 1), ((0,1), -1)][axisInd]
+        
+        # Then we have r-r.T = sin(angle) * 2 * sign * axis[axisInd];
+        # solve for sin(angle)
+        sin = (r-r.T)[rInd] / (2. * sign * axis[axisInd])
+        
+        # finally, we get the complete angle from arctan(sin/cos)
+        angle = np.arctan2(sin, cos) * 180 / np.pi
+        if angle == 0:
+            axis = (0,0,1)
+
+        self.set_params(
+            offset=tr.offset,
+            angle=angle,
+            axis=axis
+        )
+        
+    def as2D(self):
+        """Return an SRT2DTransform representing the x,y portion of this transform (if possible)"""
+        return SRT2DTransform(self)
+
+    @property
+    def params(self):
+        return {
+            'offset': tuple(self._state['offset']), 
+            'angle': self._state['angle'], 
+            'axis': tuple(self._state['axis']),
+        }
+
+    def _map(self, arr):
+        return self._get_affine()._map(arr)
+
+    def _imap(self, arr):
+        return self._get_affine()._imap(arr)
+
+    def set_params(self, offset=None, angle=None, axis=None):
+        need_update = False
+        need_update |= self._set_param('offset', offset)
+        need_update |= self._set_param('angle', angle)
+        need_update |= self._set_param('axis', axis)
+
+        if need_update:
+            self._update_affine()
+
+    def set_mapping(self, points1, points2):
+        """Set to a transformation that maps points1 onto points2.
+
+        Parameters
+        ----------
+        points1 : ndarray, shape (N, 3)
+            Input coordinates.
+        points2 : ndarray, shape (N, 3)
+            Output coordinates.
+        """
+
+        params = self.params
+        params_flat = list(params['offset']) + list(params['axis']) + [params['angle']]
+        x0 = np.array(params_flat)
+
+        def unflatten_params(x):
+            return {'offset': x[:3], 'axis': x[3:6], 'angle': x[6]}
+
+        def err_func(tr, points1, points2):
+            mapped = tr.map(points1)
+            err = (mapped - points2).flatten()
+            err = (err**2).mean()**0.5
+            return err
+
+        def flat_err_func(x, points1, points2):
+            params = unflatten_params(x)
+            tr = RT3DTransform(**params)
+            return err_func(tr, points1, points2)
+
+        result = scipy.optimize.minimize(
+            flat_err_func, x0, args=(points1, points2),
+            #method=None,
+            #method='CG',
+            #method=None,
+            #method=None,
+        )
+        params = unflatten_params(result.x)
+
+        self.set_params(**params)
+        return err_func(self, points1, points2)
+
+    def _set_param(self, param, value):
+        if value is None:
+            return False
+        current_value = self._state[param]
+        if np.isscalar(current_value):
+            assert np.isscalar(value)
+            if value == current_value:
+                return False
+        else:
+            value = np.asarray(value)
+            assert len(value) == len(current_value), f"Cannot set parameter of length {len(current_value)} with value of length {len(value)}"
+            if np.all(current_value == value):
+                return False
+        self._state[param] = value
+        return True
+
+    def _update_affine(self):
+        self._affine = None
+        self._update()
+
+    def _get_affine(self):
+        if self._affine is None:
+            self._affine = AffineTransform(dims=(3, 3))
+            self._affine.rotate(self._state['angle'], self._state['axis'])
+            self._affine.translate(self._state['offset'])
+        return self._affine
+
+
+
 class SRT3DTransform(BaseTransform):
     """Transform implemented as 4x4 affine that can always be represented as a combination of 3 matrices: scale * rotate * translate
     This transform has no shear; angles are always preserved.


### PR DESCRIPTION
i believe [this commit ](https://github.com/campagnola/coorx/commit/25beef79fe364e23cc870252610d547cd06d094d#diff-5edee97b9803732fa0958a9341f24713116157a78338fbe803e84fe51322c7c4R865)introduced a bug in SRT3DTransform.set_mapping(): when I call this method with points1.shape = points2.shape = (10,3), for example, I get TypeError("Points must have shape (N+1, N)") from matrices.affine_map. I'm not really sure why these lines were added to the top of SRT3DTransform.set_mapping (it looks like a test got left behind?) but removing them solves the problem.