### PR TITLE
Allow creation of SRT from pyqtgraph

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,15 @@ jobs:
       with:
         python-version: '3.x'
 
-    - name: Install dependencies
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libgl1-mesa-glx
+
+    - name: Install python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest numpy scipy
+        pip install pytest numpy scipy vispy pyqtgraph itk pyqt5
 
     - name: Run tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libgl1-mesa-glx
+        sudo apt-get install -y libgl1 libglx-mesa0
 
     - name: Install python dependencies
       run: |

--- a/coorx/__init__.py
+++ b/coorx/__init__.py
@@ -7,7 +7,7 @@ from .coordinates import Point, PointArray
 from .util import AxisSelectionEmbeddedTransform
 
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 
 def transform_types():

--- a/coorx/linear.py
+++ b/coorx/linear.py
@@ -1070,7 +1070,7 @@ class SRT3DTransform(Transform):
         from pyqtgraph import SRTTransform3D
 
         if not isinstance(pg_transform, SRTTransform3D):
-            raise TypeError("Input must be a Transform3D instance")
+            raise TypeError("Input must be a SRTTransform3D instance")
         tr = cls(*init_args, **init_kwargs)
         tr.set_offset(pg_transform.getTranslation())
         tr.set_scale(pg_transform.getScale())

--- a/coorx/linear.py
+++ b/coorx/linear.py
@@ -1064,6 +1064,21 @@ class SRT3DTransform(Transform):
         else:
             return tr.__rmul__(self)
 
+    @classmethod
+    def from_pyqtgraph(cls, pg_transform, *init_args, **init_kwargs):
+        """Create an SRT3DTransform from a pyqtgraph Transform3D instance"""
+        from pyqtgraph import SRTTransform3D
+
+        if not isinstance(pg_transform, SRTTransform3D):
+            raise TypeError("Input must be a Transform3D instance")
+        tr = cls(*init_args, **init_kwargs)
+        tr.set_offset(pg_transform.getTranslation())
+        tr.set_scale(pg_transform.getScale())
+        angle, axis = pg_transform.getRotation()
+        angle = -angle  # pyqtgraph uses left-handed rotations
+        tr.set_rotation(angle, axis)
+        return tr
+
 
 class PerspectiveTransform(Transform):
     """3D perspective or orthographic matrix transform using homogeneous coordinates.

--- a/coorx/tests/test_transforms.py
+++ b/coorx/tests/test_transforms.py
@@ -22,6 +22,14 @@ except ImportError:
     HAVE_VISPY = False
 
 
+try:
+    import pyqtgraph as pg
+
+    HAVE_PG = True
+except ImportError:
+    HAVE_PG = False
+
+
 NT = coorx.NullTransform
 TT = coorx.TTransform
 XT = coorx.TransposeTransform
@@ -482,6 +490,16 @@ class SRT3DTransformTest(unittest.TestCase):
         vt = tr.as_vispy()
         assert np.allclose(vt.map((1, 1, 1))[:3], tr.map((1, 1, 1)))
         assert np.allclose(vt.map((1, 3, 5))[:3], tr.map((1, 3, 5)))
+
+    @unittest.skipIf(not HAVE_PG, "pyqtgraph could not be imported")
+    def test_to_and_from_pyqtgraph(self):
+        axis = np.array((1, 1, 2))
+        axis = axis / np.linalg.norm(axis)
+        tr = coorx.SRT3DTransform(scale=(1, 2, 3), offset=(10, 5, 3), angle=120, axis=axis)
+        tr2 = coorx.SRT3DTransform.from_pyqtgraph(tr.as_pyqtgraph())
+        assert np.allclose(tr.full_matrix, tr2.full_matrix)
+        pt = np.random.normal(size=(10, 3))
+        assert np.allclose(tr.map(pt), tr2.map(pt))
 
     def test_composite(self):
         tr1 = coorx.SRT3DTransform(offset=(1, 2, 3))


### PR DESCRIPTION
The angle is backwards, so this will really bite our users. Oddly, `as_pyqtgraph` didn't have any of the same issues. I don't know why.