### PR TITLE
style: apply black formatting for qmatrix

### DIFF
--- a/coorx/base_transform.py
+++ b/coorx/base_transform.py
@@ -34,6 +34,7 @@ class Transform(object):
     where the inverse mapping is ambiguous or otherwise meaningless.
 
     """
+
     # Flags used to describe the transformation. Subclasses should define each
     # as True or False.
     # (usually used for making optimization decisions)
@@ -64,7 +65,13 @@ class Transform(object):
     # List of keys that will be saved and restored in __getstate__ and __setstate__
     state_keys = []
 
-    def __init__(self, dims:Dims=None, from_cs:StrOrNone=None, to_cs:StrOrNone=None, cs_graph:StrOrNone=None):
+    def __init__(
+        self,
+        dims: Dims = None,
+        from_cs: StrOrNone = None,
+        to_cs: StrOrNone = None,
+        cs_graph: StrOrNone = None,
+    ):
         if dims is None or np.isscalar(dims):
             dims = (dims, dims)
         if not isinstance(dims, tuple) or len(dims) != 2:
@@ -81,23 +88,22 @@ class Transform(object):
 
     @property
     def dims(self):
-        """Tuple holding the (input, output) dimensions for this transform.
-        """
+        """Tuple holding the (input, output) dimensions for this transform."""
         return self._dims
 
-    def _dims_from_params(self, params:dict, dims=None):
+    def _dims_from_params(self, params: dict, dims=None):
         """Determine dimensionality from parameters.
 
         If *dims* is provided, then it must be a tuple (in, out) and it must agree with the length of all provided parameters.
         If *dims* is not provided, then it is determined from length of parameters, which must be in agreement.
         """
         assert len(params) > 0
-        inferred_dims = {k:(len(v), len(v)) for k,v in params.items() if v is not None}
+        inferred_dims = {k: (len(v), len(v)) for k, v in params.items() if v is not None}
         if dims is not None:
-            for k,v in inferred_dims.items():
+            for k, v in inferred_dims.items():
                 assert v == dims, f"Length of {k} ({len(dims[k])}) does not match dims {dims}"
             return dims
-        
+
         if len(inferred_dims) == 0:
             msg = f"Could not determine dimensionality of transform. "
             param_names = ' '.join(list(params.keys()))
@@ -106,21 +112,24 @@ class Transform(object):
             else:
                 msg += f"Specify dims or at least one of {param_names}."
             raise Exception(msg)
-        
+
         keys = list(inferred_dims.keys())
         dims = inferred_dims[keys[0]]
         for k in keys[1:]:
-            assert inferred_dims[k] == dims, f"Length of {k} ({len(params[k])}) does not match length of {keys[0]} ({len(params[keys[0]])})"
+            assert (
+                inferred_dims[k] == dims
+            ), f"Length of {k} ({len(params[k])}) does not match length of {keys[0]} ({len(params[keys[0]])})"
         return dims
 
     @property
     def systems(self):
-        """The CoordinateSystem instances mapped from and to by this transform.
-        """
+        """The CoordinateSystem instances mapped from and to by this transform."""
         return self._systems
 
     def set_systems(self, from_cs, to_cs, cs_graph=None):
-        assert (from_cs is None) == (to_cs is None), "from_cs and to_cs must both be None or both be coordinate systems"
+        assert (from_cs is None) == (
+            to_cs is None
+        ), "from_cs and to_cs must both be None or both be coordinate systems"
         if from_cs is not None:
             if cs_graph is None and isinstance(from_cs, CoordinateSystem):
                 cs_graph = from_cs.graph
@@ -146,7 +155,7 @@ class Transform(object):
         """
         raise NotImplementedError
 
-    def imap(self, obj:Mappable):
+    def imap(self, obj: Mappable):
         """
         Return *obj* mapped through the inverse transformation.
 
@@ -164,20 +173,20 @@ class Transform(object):
         """
         raise NotImplementedError
 
-    def _prepare_and_map(self, obj:Mappable):
+    def _prepare_and_map(self, obj: Mappable):
         """
-        Convert a mappable object to a 2D numpy array, pass it through this Transform's _map method, 
-        then convert and return the result. 
-        
+        Convert a mappable object to a 2D numpy array, pass it through this Transform's _map method,
+        then convert and return the result.
+
         The Transform's _map method will be called with a 2D array
-        of shape (N, M), where N is the number of points and M is the number of dimensions. 
+        of shape (N, M), where N is the number of points and M is the number of dimensions.
         Accepts lists, tuples, and arrays of any dimensionality and flattens extra dimensions into N.
         After mapping, any flattened axes are re-expanded to match the original input shape.
 
-        For list, tuple, and array inputs, the return value is a numpy array of the same shape as 
+        For list, tuple, and array inputs, the return value is a numpy array of the same shape as
         the input, with the exception that the last dimension is determined only by the return value.
 
-        Alternatively, any class may determine how to map itself by defining a _coorx_transform() 
+        Alternatively, any class may determine how to map itself by defining a _coorx_transform()
         method that accepts this transform as an argument.
         """
         if hasattr(obj, '_coorx_transform'):
@@ -186,10 +195,15 @@ class Transform(object):
         elif isinstance(obj, (tuple, list, np.ndarray)):
             arr_2d, original_shape = self._prepare_arg_for_mapping(obj)
             if self.dims[0] not in (None, arr_2d.shape[1]):
-                raise TypeError(f"Transform maps from {self.dims[0]}D, but data to be mapped is {arr_2d.shape[1]}D")
+                raise TypeError(
+                    f"Transform maps from {self.dims[0]}D, but data to be mapped is {arr_2d.shape[1]}D"
+                )
             ret = self._map(arr_2d)
             assert ret.ndim == 2
-            assert self.dims[1] in (None, ret.shape[1]), f"Transform maps to {self.dims[1]}D, but mapping generated {ret.shape[1]}D"
+            assert self.dims[1] in (
+                None,
+                ret.shape[1],
+            ), f"Transform maps to {self.dims[1]}D, but mapping generated {ret.shape[1]}D"
             return self._restore_shape(ret, original_shape)
         else:
             raise TypeError(f"Cannot use argument for mapping: {obj}")
@@ -200,7 +214,7 @@ class Transform(object):
 
         If the argument ndim is > 2, then all dimensions except the last are flattened.
 
-        Return the reshaped array and a tuple containing the original shape. 
+        Return the reshaped array and a tuple containing the original shape.
         """
         arg = np.asarray(arg)
         original_shape = arg.shape
@@ -209,26 +223,24 @@ class Transform(object):
 
     @staticmethod
     def _restore_shape(arg, shape):
-        """Return an array with shape determined by shape[:-1] + (arg.shape[-1],)
-        """
+        """Return an array with shape determined by shape[:-1] + (arg.shape[-1],)"""
         if arg is None:
             return arg
         return arg.reshape(shape[:-1] + (arg.shape[-1],))
 
     @property
     def inverse(self):
-        """ The inverse of this transform. 
-        """
+        """The inverse of this transform."""
         if self._inverse is None:
             self._inverse = InverseTransform(self)
         return self._inverse
 
     @property
     def dynamic(self):
-        """Boolean flag that indicates whether this transform is expected to 
+        """Boolean flag that indicates whether this transform is expected to
         change frequently.
-        
-        Transforms that are flagged as dynamic will not be collapsed in 
+
+        Transforms that are flagged as dynamic will not be collapsed in
         ``ChainTransform.simplified``. This allows changes to the transform
         to propagate through the chain without requiring the chain to be
         re-simplified.
@@ -241,20 +253,18 @@ class Transform(object):
 
     @property
     def params(self):
-        """Return a dict of parameters specifying this transform.
-        """
+        """Return a dict of parameters specifying this transform."""
         raise NotImplementedError(f"{self.__class__.__name__}.params")
 
     def set_params(self, **kwds):
         """Set parameters specifying this transform.
-        
+
         Parameter names must be the same as the keys in self.params.
         """
         raise NotImplementedError(f"{self.__class__.__name__}.set_params")
 
     def save_state(self):
-        """Return serializable parameters that specify this transform.
-        """
+        """Return serializable parameters that specify this transform."""
         return {
             'type': type(self).__name__,
             'dims': self.dims,
@@ -263,14 +273,13 @@ class Transform(object):
         }
 
     def as_affine(self):
-        """Return an equivalent affine transform if possible.
-        """
+        """Return an equivalent affine transform if possible."""
         raise NotImplementedError()
 
     @property
     def full_matrix(self) -> np.ndarray:
         """
-        Return the full transformation matrix for this transform, if possible. 
+        Return the full transformation matrix for this transform, if possible.
 
         Modifying the returned array has no effect on the transform instance that generated it.
         """
@@ -279,6 +288,7 @@ class Transform(object):
     def as_vispy(self):
         """Return a VisPy transform that is equivalent to this transform, if possible."""
         from vispy.visuals.transforms import MatrixTransform
+
         # a functional default if nothing else is implemented
         return MatrixTransform(self.full_matrix.T)
 
@@ -286,12 +296,13 @@ class Transform(object):
         """Return a PyQtGraph transform that is equivalent to this transform, if possible."""
         from pyqtgraph import SRTTransform3D
         from pyqtgraph.Qt import QtGui
+
         # a functional default if nothing else is implemented
         return SRTTransform3D(QtGui.QMatrix4x4(self.full_matrix.reshape(-1)))
 
     def add_change_callback(self, cb):
         self._change_callbacks.append(cb)
-        
+
     def remove_change_callback(self, cb):
         self._change_callbacks.remove(cb)
 
@@ -359,7 +370,11 @@ class Transform(object):
         if self.systems[0] is None:
             state['_systems'] = (None, None, None)
         else:
-            state['_systems'] = (self.systems[0].name, self.systems[1].name, self.systems[0].graph.name)
+            state['_systems'] = (
+                self.systems[0].name,
+                self.systems[1].name,
+                self.systems[0].graph.name,
+            )
         return state
 
     def __setstate__(self, state):
@@ -369,8 +384,7 @@ class Transform(object):
         self.set_systems(from_cs, to_cs, graph)
 
     def copy(self, from_cs=None, to_cs=None):
-        """Return a copy of this transform.
-        """
+        """Return a copy of this transform."""
         tr = self.__class__(dims=self.dims)
         state = self.__getstate__()
         if from_cs is not None or to_cs is not None:
@@ -403,7 +417,9 @@ class Transform(object):
 
     def validate_transform_for_mul(self, tr):
         if tr.systems[1] != self.systems[0]:
-            raise TypeError(f"Cannot multiply transforms with different inner coordinate systems: {self.systems[0]} != {tr.systems[1]}")
+            raise TypeError(
+                f"Cannot multiply transforms with different inner coordinate systems: {self.systems[0]} != {tr.systems[1]}"
+            )
 
 
 class InverseTransform(Transform):
@@ -422,7 +438,12 @@ class InverseTransform(Transform):
 
     def as_affine(self):
         affine = self._inverse.as_affine()
-        return type(affine)(matrix=affine.inv_matrix, offset=affine.inv_matrix @ affine.inv_offset, from_cs=self.systems[0], to_cs=self.systems[1])
+        return type(affine)(
+            matrix=affine.inv_matrix,
+            offset=affine.inv_matrix @ affine.inv_offset,
+            from_cs=self.systems[0],
+            to_cs=self.systems[1],
+        )
 
     def copy(self, from_cs=None, to_cs=None):
         return self._inverse.copy(from_cs=to_cs, to_cs=from_cs).inverse
@@ -456,10 +477,10 @@ class InverseTransform(Transform):
     @property
     def Isometric(self):
         return self._inverse.Isometric
-    
+
     def __repr__(self):
-        return ("<Inverse of %r>" % repr(self._inverse))
-        
+        return "<Inverse of %r>" % repr(self._inverse)
+
 
 class ChangeEvent:
     def __init__(self, transform, source_event=None):
@@ -468,12 +489,11 @@ class ChangeEvent:
 
     @property
     def sources(self):
-        """A list of all transforms that changed leading to this event
-        """
+        """A list of all transforms that changed leading to this event"""
         s = [self]
         if self.source_event is not None:
             s += self.source_event.sources
-        return  s
+        return s
 
 
 # import here to avoid import cycle; needed for Transform.__mul__.


### PR DESCRIPTION
## Summary

This PR applies black formatting to Python files in the `qmatrix` branch.

## Changes

This PR contains only formatting changes applied by the `black` Python code formatter. No functional changes have been made.### Files Modified- `coorx/base_transform.py`


## Review Notes

- ✅ These are **formatting-only changes** with no functional modifications
- ✅ All changes were applied automatically by `black`
- ✅ Original functionality is preserved
- ✅ Safe to merge without detailed code review

## Merge Instructions

This formatting PR can be safely merged into `main` and then the changes can be merged back to the feature branch.

---

🤖 *Generated automatically by [brack](https://github.com/outofculture/brack) - Apply black formatting with clean diffs*