### PR TITLE
feat: add Qt geometry type support to Transform.map()

### DIFF
--- a/coorx/base_transform.py
+++ b/coorx/base_transform.py
@@ -233,7 +233,24 @@ class Transform(object):
 
         Alternatively, any class may determine how to map itself by defining a _coorx_transform()
         method that accepts this transform as an argument.
+
+        Qt geometry types (QPointF, QVector3D) and lists thereof are also accepted when Qt is available.
         """
+        try:
+            from .qt import import_qt_gui, import_qt_core
+            QtGui = import_qt_gui()
+            QtCore = import_qt_core()
+            # Use exact type checks so subclasses with __len__ (e.g. pg.Vector) fall through
+            # to the existing __len__ fallback which can reconstruct the original type.
+            if type(obj) is QtCore.QPointF:
+                return self._prepare_and_map([obj.x(), obj.y()])
+            if type(obj) is QtGui.QVector3D:
+                return self._prepare_and_map([obj.x(), obj.y(), obj.z()])
+            if isinstance(obj, (list, tuple)) and len(obj) > 0 and type(obj[0]) in (QtCore.QPointF, QtGui.QVector3D):
+                return [self._prepare_and_map(o) for o in obj]
+        except ImportError:
+            pass
+
         if hasattr(obj, '_coorx_transform'):
             # let the object decide how to apply this transform
             return obj._coorx_transform(tr=self)

--- a/coorx/qt.py
+++ b/coorx/qt.py
@@ -4,16 +4,18 @@ import sys
 
 HAVE_QT = None
 QtGui = None
+QtCore = None
 qt_lib_order = ['PyQt6', 'PySide6', 'PyQt5', 'PySide2']
 
 
 def check_qt_imported():
-    global HAVE_QT, QtGui
+    global HAVE_QT, QtGui, QtCore
     if HAVE_QT is None:
         for qt_lib in qt_lib_order:
             if f'{qt_lib}.QtGui' in sys.modules:
                 HAVE_QT = True
                 QtGui = importlib.import_module(f'{qt_lib}.QtGui')
+                QtCore = importlib.import_module(f'{qt_lib}.QtCore')
                 break
     return HAVE_QT
 
@@ -23,7 +25,7 @@ check_qt_imported()
 
 def import_qt_gui():
     """Import QtGui and return it."""
-    global HAVE_QT, QtGui
+    global HAVE_QT, QtGui, QtCore
     if not HAVE_QT:
         check_qt_imported()
 
@@ -35,7 +37,16 @@ def import_qt_gui():
         for qt_lib in qt_lib_order:
             with contextlib.suppress(ImportError):
                 QtGui = importlib.import_module(f'{qt_lib}.QtGui')
+                QtCore = importlib.import_module(f'{qt_lib}.QtCore')
                 HAVE_QT = True
                 return QtGui
 
     raise ImportError(f'No importable Qt library found (tried {", ".join(qt_lib_order)})')
+
+
+def import_qt_core():
+    """Import QtCore and return it."""
+    import_qt_gui()  # ensures QtCore is populated alongside QtGui
+    if QtCore is None:
+        raise ImportError(f'No importable Qt library found (tried {", ".join(qt_lib_order)})')
+    return QtCore

--- a/coorx/tests/test_transforms.py
+++ b/coorx/tests/test_transforms.py
@@ -199,6 +199,93 @@ class VectorMapping(unittest.TestCase):
         self.assertEqual(mapped.z(), 3 * 4 + 7)
 
 
+try:
+    from coorx.qt import import_qt_gui, import_qt_core
+    _QtGui = import_qt_gui()
+    _QtCore = import_qt_core()
+    HAVE_QT_GUI = True
+except ImportError:
+    HAVE_QT_GUI = False
+
+
+class QtGeometryMappingTest(unittest.TestCase):
+    """Tests that Transform.map() handles Qt geometry types directly."""
+
+    @unittest.skipUnless(HAVE_QT_GUI, "Qt GUI not available")
+    def test_map_qpointf(self):
+        tr = coorx.STTransform(scale=(2, 3), offset=(10, 20))
+        pt = _QtCore.QPointF(1.0, 2.0)
+        result = tr.map(pt)
+        np.testing.assert_allclose(result, [1 * 2 + 10, 2 * 3 + 20])
+
+    @unittest.skipUnless(HAVE_QT_GUI, "Qt GUI not available")
+    def test_map_qvector3d(self):
+        tr = coorx.STTransform(scale=(2, 3, 4), offset=(5, 6, 7))
+        pt = _QtGui.QVector3D(1.0, 2.0, 3.0)
+        result = tr.map(pt)
+        np.testing.assert_allclose(result, [1 * 2 + 5, 2 * 3 + 6, 3 * 4 + 7])
+
+    @unittest.skipUnless(HAVE_QT_GUI, "Qt GUI not available")
+    def test_map_list_of_qpointf(self):
+        tr = coorx.STTransform(scale=(2, 3), offset=(10, 20))
+        pts = [_QtCore.QPointF(1.0, 2.0), _QtCore.QPointF(3.0, 4.0)]
+        results = tr.map(pts)
+        assert len(results) == 2
+        np.testing.assert_allclose(results[0], [1 * 2 + 10, 2 * 3 + 20])
+        np.testing.assert_allclose(results[1], [3 * 2 + 10, 4 * 3 + 20])
+
+    @unittest.skipUnless(HAVE_QT_GUI, "Qt GUI not available")
+    def test_map_list_of_qvector3d(self):
+        tr = coorx.STTransform(scale=(2, 3, 4), offset=(5, 6, 7))
+        pts = [_QtGui.QVector3D(1.0, 2.0, 3.0), _QtGui.QVector3D(4.0, 5.0, 6.0)]
+        results = tr.map(pts)
+        assert len(results) == 2
+        np.testing.assert_allclose(results[0], [1 * 2 + 5, 2 * 3 + 6, 3 * 4 + 7])
+        np.testing.assert_allclose(results[1], [4 * 2 + 5, 5 * 3 + 6, 6 * 4 + 7])
+
+    @unittest.skipUnless(HAVE_QT_GUI, "Qt GUI not available")
+    def test_map_tuple_of_qpointf(self):
+        tr = coorx.STTransform(scale=(2, 3), offset=(10, 20))
+        pts = (_QtCore.QPointF(1.0, 2.0), _QtCore.QPointF(3.0, 4.0))
+        results = tr.map(pts)
+        assert len(results) == 2
+        np.testing.assert_allclose(results[0], [1 * 2 + 10, 2 * 3 + 20])
+        np.testing.assert_allclose(results[1], [3 * 2 + 10, 4 * 3 + 20])
+
+    @unittest.skipUnless(HAVE_QT_GUI, "Qt GUI not available")
+    def test_map_qpointf_with_affine(self):
+        tr = coorx.AffineTransform(dims=(2, 2))
+        tr.translate([5, 7])
+        pt = _QtCore.QPointF(1.0, 2.0)
+        result = tr.map(pt)
+        np.testing.assert_allclose(result, [6.0, 9.0])
+
+    @unittest.skipUnless(HAVE_QT_GUI, "Qt GUI not available")
+    def test_map_qpointf_with_composite(self):
+        # (t1 * t2)(x) = t1(t2(x)), so t2 is applied first
+        t1 = coorx.TTransform(offset=(1, 1))
+        t2 = coorx.STTransform(scale=(2, 2), offset=(0, 0))
+        tr = t1 * t2
+        pt = _QtCore.QPointF(3.0, 4.0)
+        result = tr.map(pt)
+        # t2 scales: (6, 8), then t1 adds offset: (7, 9)
+        np.testing.assert_allclose(result, [7.0, 9.0])
+
+    @unittest.skipUnless(HAVE_QT_GUI, "Qt GUI not available")
+    def test_map_qpointf_with_ttransform(self):
+        tr = coorx.TTransform(offset=(100, 200))
+        pt = _QtCore.QPointF(5.0, 6.0)
+        result = tr.map(pt)
+        np.testing.assert_allclose(result, [105.0, 206.0])
+
+    @unittest.skipUnless(HAVE_QT_GUI, "Qt GUI not available")
+    def test_map_empty_list_raises(self):
+        tr = coorx.STTransform(scale=(2, 3), offset=(10, 20))
+        # empty list has no Qt type to detect and 0 dims — base class raises TypeError
+        with self.assertRaises(TypeError):
+            tr.map([])
+
+
 class CompositeTransform(unittest.TestCase):
     def test_transform_composite(self):
         # Make dummy classes for easier distinguishing the transforms


### PR DESCRIPTION
## Summary

- `Transform.map()` now accepts `QPointF` and `QVector3D` directly, as well as `list`/`tuple` collections of them
- Adds `import_qt_core()` to `coorx/qt.py` so Qt Core types are accessible consistently alongside Qt Gui types
- Uses exact type-checking (`type(obj) is ...`) so subclasses like `pg.Vector` (which has `__len__`) continue to fall through to the existing array path

## Test plan

- [x] `test_map_qpointf` — basic scale+translate via STTransform
- [x] `test_map_qvector3d` — 3D scale+translate via STTransform
- [x] `test_map_list_of_qpointf` — batch mapping of a list
- [x] `test_map_list_of_qvector3d` — batch 3D mapping
- [x] `test_map_tuple_of_qpointf` — tuple input works the same as list
- [x] `test_map_qpointf_with_affine` — AffineTransform with translation
- [x] `test_map_qpointf_with_composite` — CompositeTransform (scale then translate)
- [x] `test_map_qpointf_with_ttransform` — pure translation transform
- [x] `test_map_empty_list_raises` — empty list falls through and raises the existing TypeError
- All tests skipped gracefully when Qt is not available

🤖 Generated with [Claude Code](https://claude.com/claude-code)