### PR TITLE
Derived transforms no longer register in the coordinate system graph

### DIFF
--- a/coorx/base_transform.py
+++ b/coorx/base_transform.py
@@ -358,13 +358,17 @@ class Transform(object):
 
         By default, the returned transform has no coordinate systems. If *from_cs* and
         *to_cs* are both given (str or CoordinateSystem), they are set on the result;
-        giving only one of the two raises ValueError.
+        giving only one of the two raises ValueError, as does giving two systems that
+        both already exist in the graph (the result may never replace or shadow an
+        existing graph edge).
         """
         if (from_cs is None) != (to_cs is None):
             raise ValueError("as_affine requires either both from_cs and to_cs or neither")
         affine = self._as_affine()
         if from_cs is not None:
-            affine.set_systems(from_cs, to_cs, self._graph_for_new_systems(from_cs, to_cs))
+            graph = self._graph_for_new_systems(from_cs, to_cs)
+            self._check_derived_systems([from_cs, to_cs], from_cs, to_cs, graph)
+            affine.set_systems(from_cs, to_cs, graph)
         return affine
 
     def _as_affine(self):
@@ -375,19 +379,46 @@ class Transform(object):
         raise NotImplementedError()
 
     def _graph_for_new_systems(self, from_cs, to_cs):
-        """Return the cs_graph argument to use when setting systems on a derived transform.
+        """Return the graph in which a derived transform's systems should be registered.
 
-        If *from_cs* or *to_cs* is a CoordinateSystem instance, its graph takes precedence
-        (set_systems handles the from_cs case itself); otherwise the graph of this
-        transform's own systems is used, falling back to the default graph.
+        If *from_cs* or *to_cs* is a CoordinateSystem instance, its graph takes precedence;
+        otherwise the graph of this transform's own systems is used, falling back to the
+        default graph.
         """
-        if isinstance(from_cs, CoordinateSystem):
-            return None
-        if isinstance(to_cs, CoordinateSystem):
-            return to_cs.graph
-        if self.systems[0] is not None:
-            return self.systems[0].graph
-        return None
+        for cs in (from_cs, to_cs):
+            if isinstance(cs, CoordinateSystem):
+                return cs.graph
+        for cs in self.systems:
+            if cs is not None:
+                return cs.graph
+        return CoordinateSystemGraph.get_graph(None)
+
+    @staticmethod
+    def _check_derived_systems(resolved, from_cs, to_cs, graph):
+        """Check that registering a derived transform with *resolved* systems cannot
+        modify existing graph structure.
+
+        Derived system names (those not explicitly given as from_cs/to_cs) must not
+        collide with systems already in *graph*, and at most one of the explicitly
+        given from_cs/to_cs may be an existing system; together these guarantee that
+        the registered copy introduces at least one new system and therefore can
+        never replace or shadow an existing graph edge.
+        """
+        def exists(s):
+            return isinstance(s, CoordinateSystem) or s in graph.systems
+
+        for i, s in enumerate(resolved):
+            explicit = (i == 0 and from_cs is not None) or (i == len(resolved) - 1 and to_cs is not None)
+            if not explicit and exists(s):
+                raise ValueError(
+                    f"Derived name for coordinate system '{s}' already exists in {graph}; "
+                    "derived system names must be new."
+                )
+        if from_cs is not None and to_cs is not None and exists(resolved[0]) and exists(resolved[-1]):
+            raise ValueError(
+                f"Both from_cs ('{resolved[0]}') and to_cs ('{resolved[-1]}') are existing coordinate "
+                f"systems in {graph}; at most one may already exist."
+            )
 
     @property
     def full_matrix(self) -> np.ndarray:
@@ -551,17 +582,32 @@ class Transform(object):
         registration; otherwise the copy is registered in the same graph as the
         original (or the default graph if the original has no systems).
 
+        The registered copy may never replace or shadow an existing graph edge:
+        names derived via *system_names* must not collide with existing systems, and
+        at most one of *from_cs* / *to_cs* may be an existing system (ValueError
+        otherwise).
+
         Examples
         --------
         tr.copy()                                  # no systems
         tr.copy(system_names='_frozen')            # 'a'->'b' becomes 'a_frozen'->'b_frozen'
         tr.copy(from_cs='global', system_names='_frame12')
         """
-        state = strip_systems_from_state(self.save_state())
-        new = self.from_state(state)
         resolved = self._resolve_copy_systems(list(self.systems), from_cs, to_cs, system_names)
-        if resolved is not None:
-            new.set_systems(resolved[0], resolved[-1], self._graph_for_new_systems(resolved[0], resolved[-1]))
+        if resolved is None:
+            return self.from_state(strip_systems_from_state(self.save_state()))
+        graph = self._graph_for_new_systems(from_cs, to_cs)
+        self._check_derived_systems(resolved, from_cs, to_cs, graph)
+        return self._copy_registered(resolved[0], resolved[-1], graph)
+
+    def _copy_registered(self, from_cs, to_cs, cs_graph):
+        """Return a copy with the given systems assigned.
+
+        Internal: callers are responsible for having validated the systems against
+        the graph (see _check_derived_systems).
+        """
+        new = self.from_state(strip_systems_from_state(self.save_state()))
+        new.set_systems(from_cs, to_cs, cs_graph)
         return new
 
     @staticmethod
@@ -672,6 +718,9 @@ class InverseTransform(Transform):
 
     def copy(self, from_cs=None, to_cs=None, system_names=None):
         return self._state['inverse'].copy(from_cs=to_cs, to_cs=from_cs, system_names=system_names).inverse
+
+    def _copy_registered(self, from_cs, to_cs, cs_graph):
+        return self._state['inverse']._copy_registered(to_cs, from_cs, cs_graph).inverse
 
     def set_params(self, inverse):
         if isinstance(inverse, Transform):

--- a/coorx/base_transform.py
+++ b/coorx/base_transform.py
@@ -16,6 +16,20 @@ class DependentTransformError(Exception):
     pass
 
 
+def strip_systems_from_state(state):
+    """Return a copy of a transform state with all 'systems' keys recursively removed.
+
+    Nested transform states (e.g. InverseTransform's 'inverse' parameter or
+    PerspectiveTransform's 'affine' parameter) are stripped as well.
+    """
+    if isinstance(state, dict):
+        return {k: strip_systems_from_state(v) for k, v in state.items() if k != 'systems'}
+    elif isinstance(state, list):
+        return [strip_systems_from_state(v) for v in state]
+    else:
+        return state
+
+
 class Transform(object):
     """
     Transform is a base class that defines a pair of complementary
@@ -339,9 +353,41 @@ class Transform(object):
             cls._param_spec_dict = {p.name: p for p in cls.parameter_spec}
         return cls._param_spec_dict
 
-    def as_affine(self):
-        """Return an equivalent affine transform if possible."""
+    def as_affine(self, from_cs=None, to_cs=None):
+        """Return an equivalent affine transform if possible.
+
+        By default, the returned transform has no coordinate systems. If *from_cs* and
+        *to_cs* are both given (str or CoordinateSystem), they are set on the result;
+        giving only one of the two raises ValueError.
+        """
+        if (from_cs is None) != (to_cs is None):
+            raise ValueError("as_affine requires either both from_cs and to_cs or neither")
+        affine = self._as_affine()
+        if from_cs is not None:
+            affine.set_systems(from_cs, to_cs, self._graph_for_new_systems(from_cs, to_cs))
+        return affine
+
+    def _as_affine(self):
+        """Return an equivalent affine transform with no coordinate systems.
+
+        This method must be redefined in subclasses that support affine conversion.
+        """
         raise NotImplementedError()
+
+    def _graph_for_new_systems(self, from_cs, to_cs):
+        """Return the cs_graph argument to use when setting systems on a derived transform.
+
+        If *from_cs* or *to_cs* is a CoordinateSystem instance, its graph takes precedence
+        (set_systems handles the from_cs case itself); otherwise the graph of this
+        transform's own systems is used, falling back to the default graph.
+        """
+        if isinstance(from_cs, CoordinateSystem):
+            return None
+        if isinstance(to_cs, CoordinateSystem):
+            return to_cs.graph
+        if self.systems[0] is not None:
+            return self.systems[0].graph
+        return None
 
     @property
     def full_matrix(self) -> np.ndarray:
@@ -482,20 +528,76 @@ class Transform(object):
             self._systems = (None, None)
             self.set_systems(from_cs, to_cs, graph)
 
-    def copy(self, from_cs=None, to_cs=None):
-        """Return a copy of this transform."""
-        state = self.save_state()
-        if from_cs is not None or to_cs is not None:
-            from_cs = from_cs or self.systems[0]
-            to_cs = to_cs or self.systems[1]
-            graph = None
-            if from_cs is not None and not isinstance(from_cs, str):
-                graph = from_cs.graph.name
-            if graph is None and to_cs is not None and not isinstance(to_cs, str):
-                graph = to_cs.graph.name
-            state['systems'] = (from_cs, to_cs)
-            state['graph'] = graph
-        return self.from_state(state)
+    def copy(self, from_cs=None, to_cs=None, system_names=None):
+        """Return a copy of this transform.
+
+        By default, the copy has no coordinate systems and is not registered in any
+        coordinate system graph. To register the copy, its systems must be named
+        explicitly; if any of the arguments below is given, then names must resolve
+        for *all* of the copy's systems, otherwise ValueError is raised.
+
+        Parameters
+        ----------
+        from_cs : str | CoordinateSystem | None
+            Coordinate system to assign to the copy's input.
+        to_cs : str | CoordinateSystem | None
+            Coordinate system to assign to the copy's output.
+        system_names : dict | str | None
+            Names for systems not covered by *from_cs* / *to_cs*, derived from the
+            original systems' names: a dict maps original name to new name (a missing
+            key raises ValueError); a str is appended to the original name as a suffix.
+
+        If *from_cs* or *to_cs* is a CoordinateSystem instance, its graph is used for
+        registration; otherwise the copy is registered in the same graph as the
+        original (or the default graph if the original has no systems).
+
+        Examples
+        --------
+        tr.copy()                                  # no systems
+        tr.copy(system_names='_frozen')            # 'a'->'b' becomes 'a_frozen'->'b_frozen'
+        tr.copy(from_cs='global', system_names='_frame12')
+        """
+        state = strip_systems_from_state(self.save_state())
+        new = self.from_state(state)
+        resolved = self._resolve_copy_systems(list(self.systems), from_cs, to_cs, system_names)
+        if resolved is not None:
+            new.set_systems(resolved[0], resolved[-1], self._graph_for_new_systems(resolved[0], resolved[-1]))
+        return new
+
+    @staticmethod
+    def _resolve_copy_systems(systems, from_cs, to_cs, system_names):
+        """Resolve new coordinate systems for a copy of a transform.
+
+        *systems* is the ordered list of original CoordinateSystem|None instances
+        (length >= 2; first is the input system, last is the output system).
+        Returns a list of resolved systems (str or CoordinateSystem), or None if no
+        systems were requested (all three args are None).
+        """
+        if from_cs is None and to_cs is None and system_names is None:
+            return None
+        resolved = []
+        for i, cs in enumerate(systems):
+            if i == 0 and from_cs is not None:
+                resolved.append(from_cs)
+            elif i == len(systems) - 1 and to_cs is not None:
+                resolved.append(to_cs)
+            elif cs is None:
+                raise ValueError(
+                    f"Cannot derive a name for the copy's coordinate system at position {i}: the "
+                    "original transform has no system there; specify from_cs/to_cs."
+                )
+            elif isinstance(system_names, dict):
+                if cs.name not in system_names:
+                    raise ValueError(f"system_names has no entry for coordinate system '{cs.name}'")
+                resolved.append(system_names[cs.name])
+            elif isinstance(system_names, str):
+                resolved.append(cs.name + system_names)
+            else:
+                raise ValueError(
+                    f"No name given for the copy's coordinate system derived from '{cs.name}'; "
+                    "specify from_cs/to_cs or system_names."
+                )
+        return resolved
 
     def save_state(self):
         """Return serializable parameters that specify this transform. Distinct from __getstate__
@@ -538,6 +640,8 @@ class Transform(object):
         return True
 
     def validate_transform_for_mul(self, tr):
+        if tr.systems[1] is None or self.systems[0] is None:
+            return
         if tr.systems[1] != self.systems[0]:
             raise TypeError(
                 f"Cannot multiply transforms with different inner coordinate systems: {self.systems[0]} != {tr.systems[1]}"
@@ -559,17 +663,15 @@ class InverseTransform(Transform):
     def set_systems(self, from_cs, to_cs, cs_graph=None):
         raise DependentTransformError("Cannot set systems on a dependent inverse transform")
 
-    def as_affine(self):
+    def _as_affine(self):
         affine = self._state["inverse"].as_affine()
         return type(affine)(
             matrix=affine.inv_matrix,
             offset=affine.inv_matrix @ affine.inv_offset,
-            from_cs=self.systems[0],
-            to_cs=self.systems[1],
         )
 
-    def copy(self, from_cs=None, to_cs=None):
-        return self._state['inverse'].copy(from_cs=to_cs, to_cs=from_cs).inverse
+    def copy(self, from_cs=None, to_cs=None, system_names=None):
+        return self._state['inverse'].copy(from_cs=to_cs, to_cs=from_cs, system_names=system_names).inverse
 
     def set_params(self, inverse):
         if isinstance(inverse, Transform):

--- a/coorx/composite.py
+++ b/coorx/composite.py
@@ -89,7 +89,10 @@ class CompositeTransform(Transform):
             key raises ValueError); a str is appended to the original name as a suffix.
 
         Each sub-transform is copied with its resolved endpoint pair, so the entire
-        chain is registered as new graph edges.
+        chain is registered as new graph edges. The registered chain may never replace
+        or shadow existing graph edges: names derived via *system_names* must not
+        collide with existing systems, and at most one of *from_cs* / *to_cs* may be
+        an existing system (ValueError otherwise).
 
         Examples
         --------
@@ -106,7 +109,9 @@ class CompositeTransform(Transform):
         if resolved is None:
             copies = [t.copy() for t in self.transforms]
         else:
-            copies = [t.copy(from_cs=resolved[i], to_cs=resolved[i + 1]) for i, t in enumerate(self.transforms)]
+            graph = self._graph_for_new_systems(from_cs, to_cs)
+            self._check_derived_systems(resolved, from_cs, to_cs, graph)
+            copies = [t._copy_registered(resolved[i], resolved[i + 1], graph) for i, t in enumerate(self.transforms)]
         return CompositeTransform(copies, dynamic=self.dynamic)
 
     @property

--- a/coorx/composite.py
+++ b/coorx/composite.py
@@ -68,10 +68,46 @@ class CompositeTransform(Transform):
     def set_systems(self, from_cs, to_cs, cs_graph=None):
         raise DependentTransformError("Cannot set systems on a CompositeTransform")
 
-    def copy(self, from_cs=None, to_cs=None):
-        if from_cs is not None or to_cs is not None:
-            raise ValueError("Cannot set systems on a CompositeTransform")
-        return super().copy()
+    def copy(self, from_cs=None, to_cs=None, system_names=None):
+        """Return a copy of this transform chain.
+
+        By default, the copied sub-transforms have no coordinate systems and are not
+        registered in any coordinate system graph. To register the copy, systems must
+        be named explicitly for every point along the chain; if any of the arguments
+        below is given, then names must resolve for *all* of the chain's systems,
+        otherwise ValueError is raised.
+
+        Parameters
+        ----------
+        from_cs : str | CoordinateSystem | None
+            Coordinate system to assign to the copy's input.
+        to_cs : str | CoordinateSystem | None
+            Coordinate system to assign to the copy's output.
+        system_names : dict | str | None
+            Names for systems not covered by *from_cs* / *to_cs*, derived from the
+            original systems' names: a dict maps original name to new name (a missing
+            key raises ValueError); a str is appended to the original name as a suffix.
+
+        Each sub-transform is copied with its resolved endpoint pair, so the entire
+        chain is registered as new graph edges.
+
+        Examples
+        --------
+        chain.copy()                      # system-less copies of all sub-transforms
+        chain.copy(system_names='_f12')   # 'a'->'b'->'c' becomes 'a_f12'->'b_f12'->'c_f12'
+        chain.copy(from_cs='global', system_names='_frame12')
+        """
+        if len(self.transforms) == 0:
+            if from_cs is not None or to_cs is not None or system_names is not None:
+                raise ValueError("Cannot set systems on an empty CompositeTransform")
+            return CompositeTransform([], dynamic=self.dynamic)
+        systems = [self.transforms[0].systems[0]] + [t.systems[1] for t in self.transforms]
+        resolved = Transform._resolve_copy_systems(systems, from_cs, to_cs, system_names)
+        if resolved is None:
+            copies = [t.copy() for t in self.transforms]
+        else:
+            copies = [t.copy(from_cs=resolved[i], to_cs=resolved[i + 1]) for i, t in enumerate(self.transforms)]
+        return CompositeTransform(copies, dynamic=self.dynamic)
 
     @property
     def dims(self):
@@ -85,6 +121,8 @@ class CompositeTransform(Transform):
 
         transforms = [t if isinstance(t, Transform) else create_transform(**t) for t in transforms or []]
         for i in range(len(transforms) - 1):
+            if transforms[i].systems[1] is None or transforms[i + 1].systems[0] is None:
+                continue
             if transforms[i].systems[1] != transforms[i + 1].systems[0]:
                 raise TypeError(
                     f"Coordinate systems of transform {transforms[i]} "
@@ -179,7 +217,7 @@ class CompositeTransform(Transform):
             coords = tr.imap(coords)
         return coords
 
-    def as_affine(self):
+    def _as_affine(self):
         ret = None
         for tr in self.transforms:
             if ret is None:
@@ -212,9 +250,7 @@ class CompositeTransform(Transform):
         tr : instance of Transform
             The transform to use.
         """
-        print("appending", tr)
         self.transforms.append(tr)
-        print("appended?", self.transforms)
         tr.add_change_callback(self._subtr_changed, keep_reference=False, duplicates='ignore')
         self._update()
 

--- a/coorx/linear.py
+++ b/coorx/linear.py
@@ -37,12 +37,10 @@ class NullTransform(Transform):
         """
         return coords
 
-    def as_affine(self):
+    def _as_affine(self):
         return AffineTransform(
             matrix=np.eye(self.dims[0]),
             offset=np.zeros(self.dims[0]),
-            from_cs=self.systems[0],
-            to_cs=self.systems[1],
         )
 
     @property
@@ -57,7 +55,7 @@ class NullTransform(Transform):
         if isinstance(tr.inverse, CompositeTransform):
             return tr.inverse.__mul__(self.inverse).inverse
         self.validate_transform_for_mul(tr)
-        return tr.copy(from_cs=tr.systems[0], to_cs=self.systems[1])
+        return tr.copy()
 
     def __rmul__(self, tr):
         from coorx import CompositeTransform
@@ -67,7 +65,7 @@ class NullTransform(Transform):
         if isinstance(tr.inverse, CompositeTransform):
             return tr.inverse.__rmul__(self.inverse).inverse
         tr.validate_transform_for_mul(self)
-        return tr.copy(from_cs=self.systems[0], to_cs=tr.systems[1])
+        return tr.copy()
 
 
 class TransposeTransform(Transform):
@@ -106,12 +104,10 @@ class TransposeTransform(Transform):
     def params(self):
         return {'axis_order': self.axis_order}
 
-    def as_affine(self):
+    def _as_affine(self):
         return AffineTransform(
             matrix=np.eye(self.dims[0])[:, self.axis_order],
             offset=np.zeros(self.dims[0]),
-            from_cs=self.systems[0],
-            to_cs=self.systems[1],
         )
 
     def __rmul__(self, tr):
@@ -119,8 +115,6 @@ class TransposeTransform(Transform):
             tr.validate_transform_for_mul(self)
             return TransposeTransform(
                 axis_order=tuple(self._map(np.array(tr.axis_order))),
-                from_cs=self.systems[0],
-                to_cs=tr.systems[1],
             )
         return super().__rmul__(tr)
 
@@ -207,8 +201,8 @@ class TTransform(Transform):
         offset = np.asarray(offset)
         self.offset = self.offset + offset
 
-    def as_affine(self):
-        m = AffineTransform(dims=self.dims, from_cs=self.systems[0], to_cs=self.systems[1])
+    def _as_affine(self):
+        m = AffineTransform(dims=self.dims)
         m.translate(self.offset)
         return m
 
@@ -216,14 +210,12 @@ class TTransform(Transform):
         return STTransform(
             offset=self.offset,
             scale=(1,) * self.dims[0],
-            from_cs=self.systems[0],
-            to_cs=self.systems[1],
         )
 
     def __mul__(self, tr):
         self.validate_transform_for_mul(tr)
         if isinstance(tr, TTransform):
-            return TTransform(self.offset + tr.offset, from_cs=tr.systems[0], to_cs=self.systems[1])
+            return TTransform(self.offset + tr.offset)
         elif isinstance(tr, STTransform):
             return self.as_st() * tr
         elif isinstance(tr, AffineTransform):
@@ -356,8 +348,8 @@ class STTransform(Transform):
             trans = self.scale * (1 - zoom) * center + self.offset
         self.set_params(scale=scale, offset=trans)
 
-    def as_affine(self):
-        m = AffineTransform(dims=self.dims, from_cs=self.systems[0], to_cs=self.systems[1])
+    def _as_affine(self):
+        m = AffineTransform(dims=self.dims)
         m.zoom(self.scale)
         m.translate(self.offset)
         return m
@@ -435,7 +427,7 @@ class STTransform(Transform):
         if isinstance(tr, STTransform):
             s = self.scale * tr.scale
             t = self.offset + (tr.offset * self.scale)
-            return STTransform(scale=s, offset=t, from_cs=tr.systems[0], to_cs=self.systems[1])
+            return STTransform(scale=s, offset=t)
         elif isinstance(tr, AffineTransform):
             return self.as_affine() * tr
         else:
@@ -558,12 +550,10 @@ class AffineTransform(Transform):
     def inv_offset(self):
         return -self._state["offset"]
 
-    def as_affine(self):
+    def _as_affine(self):
         return AffineTransform(
             matrix=self.matrix,
             offset=self.offset,
-            from_cs=self.systems[0],
-            to_cs=self.systems[1],
         )
 
     @property
@@ -665,9 +655,7 @@ class AffineTransform(Transform):
         self.validate_transform_for_mul(tr)
         if isinstance(tr, AffineTransform):
             m = np.dot(self.full_matrix, tr.full_matrix)
-            return AffineTransform(
-                matrix=m[:-1, :-1], offset=m[:-1, -1], from_cs=tr.systems[0], to_cs=self.systems[1]
-            )
+            return AffineTransform(matrix=m[:-1, :-1], offset=m[:-1, -1])
         return tr.__rmul__(self)
 
     def __eq__(self, tr):
@@ -692,14 +680,6 @@ class AffineTransform(Transform):
         offset = matrix[:-1, -1]
         matrix = matrix[:-1, :-1]
         return cls(matrix=matrix, offset=offset, *init_args, **init_kwargs)
-
-    def copy(self, from_cs=None, to_cs=None):
-        return AffineTransform(
-            matrix=self.matrix,
-            offset=self.offset,
-            from_cs=from_cs or self.systems[0],
-            to_cs=to_cs or self.systems[1],
-        )
 
 
 class SRT2DTransform:
@@ -1004,8 +984,8 @@ class SRT3DTransform(Transform):
         self.set_params(**params)
         return err_func(self, points1, points2)
 
-    def as_affine(self):
-        affine = AffineTransform(dims=(3, 3), from_cs=self.systems[0], to_cs=self.systems[1])
+    def _as_affine(self):
+        affine = AffineTransform(dims=(3, 3))
         affine.zoom(self._state["scale"])
         affine.rotate(self._state["angle"], self._state["axis"])
         affine.translate(self._state["offset"])
@@ -1086,7 +1066,7 @@ class PerspectiveTransform(Transform):
         out = self.affine.map(arr4)
         return out[:, :3] / out[:, 3:4]
 
-    def as_affine(self):
+    def _as_affine(self):
         # TODO is this correct?
         return self.affine.as_affine()
 

--- a/coorx/tests/test_systems.py
+++ b/coorx/tests/test_systems.py
@@ -270,9 +270,14 @@ def test_copy(type1, inverse1, inverse2):
         cs2_from_cs1.copy(from_cs="cs4")
     with raises(ValueError):
         cs2_from_cs1.copy(to_cs="cs5")
-    copy = cs2_from_cs1.copy(from_cs="cs4", to_cs="cs5")
-    assert str(copy.systems[0]) == "cs4"
-    assert str(copy.systems[1]) == "cs5"
+    with raises(ValueError):
+        # both endpoints already exist in the graph
+        cs2_from_cs1.copy(from_cs="cs1", to_cs="cs2")
+    new_from = f"cs4_{type1}_{inverse1}_{inverse2}"
+    new_to = f"cs5_{type1}_{inverse1}_{inverse2}"
+    copy = cs2_from_cs1.copy(from_cs=new_from, to_cs=new_to)
+    assert str(copy.systems[0]) == new_from
+    assert str(copy.systems[1]) == new_to
 
 
 def test_composite_copy():
@@ -522,3 +527,53 @@ def test_save_state_preserves_systems():
     assert restored.systems[0].graph is graph
     pts = np.array([[1.0, 2.0], [3.0, 4.0]])
     assert np.all(restored.map(pts) == tr.map(pts))
+
+
+def test_copy_cannot_clobber_graph():
+    graph = CoordinateSystemGraph.get_graph("copy_clobber_graph", create=True)
+    tr = STTransform(scale=[2, 3], offset=[1, 2], from_cs="A", to_cs="B", cs_graph=graph)
+
+    with raises(ValueError):
+        tr.copy(from_cs="A", to_cs="B")
+    with raises(ValueError):
+        tr.as_affine(from_cs="A", to_cs="B")
+    with raises(ValueError):
+        tr.as_affine(from_cs="B", to_cs="A")
+
+    copy = tr.copy(from_cs="A", to_cs="B_frozen")
+    assert copy.systems[0] is graph.system("A")
+
+    tr.copy(system_names="_f1")
+    with raises(ValueError):
+        tr.copy(system_names="_f1")
+    with raises(ValueError):
+        tr.copy(system_names={"A": "A", "B": "B2"})
+
+    assert graph.transform("A", "B") is tr
+
+
+def test_composite_copy_cannot_clobber_graph():
+    graph = CoordinateSystemGraph.get_graph("comp_clobber_graph", create=True)
+    a_to_b = STTransform(scale=[2, 2], offset=[1, 1], from_cs="A", to_cs="B", cs_graph=graph)
+    b_to_c = AffineTransform(matrix=[[0, 1], [1, 0]], offset=[3, 4], from_cs="B", to_cs="C", cs_graph=graph)
+    chain = graph.transform("A", "C")
+
+    with raises(ValueError):
+        chain.copy(from_cs="A", to_cs="C", system_names="_f1")
+    with raises(ValueError):
+        chain.copy(system_names={"A": "A2", "B": "B", "C": "C2"})
+    # the failed copies must not have partially registered anything
+    assert set(graph.systems) == {"A", "B", "C"}
+
+    chain.copy(system_names="_f1")
+    with raises(ValueError):
+        chain.copy(system_names="_f1")
+
+    # pinning a single endpoint to an existing system is allowed, on either end
+    copy = chain.copy(from_cs="A", system_names="_f2")
+    assert copy.transforms[0].systems[0] is graph.system("A")
+    copy = chain.copy(to_cs="C", system_names="_f3")
+    assert copy.transforms[-1].systems[1] is graph.system("C")
+
+    assert graph.transform("A", "B") is a_to_b
+    assert graph.transform("B", "C") is b_to_c

--- a/coorx/tests/test_systems.py
+++ b/coorx/tests/test_systems.py
@@ -6,7 +6,7 @@ import pytest
 from coorx import CompositeTransform
 from coorx import create_transform, Point
 from coorx.coordinates import PointArray
-from coorx.linear import STTransform
+from coorx.linear import AffineTransform, STTransform
 from coorx.systems import CoordinateSystemGraph
 from pytest import raises
 
@@ -221,11 +221,11 @@ def test_transform_mapping(type1, type2, inverse1, inverse2):
     assert str(explicitly_mapped.system) == "cs3"
 
     with contextlib.suppress(NotImplementedError):  # ignore non-affine transforms here
-        affine_mapped = cs3_from_cs2.as_affine().map(cs2_from_cs1.as_affine().map(point))
-        assert str(affine_mapped.system) == "cs3"
+        affine_mapped = cs3_from_cs2.as_affine().map(cs2_from_cs1.as_affine().map(point.coordinates))
+        assert np.allclose(affine_mapped, explicitly_mapped.coordinates, equal_nan=True)
 
-    mult_mapped = (cs3_from_cs2 * cs2_from_cs1).map(point)
-    assert str(mult_mapped.system) == "cs3"
+    mult_mapped = (cs3_from_cs2 * cs2_from_cs1).map(point.coordinates)
+    assert np.allclose(mult_mapped, explicitly_mapped.coordinates, equal_nan=True)
 
     composite_mapped = CompositeTransform([cs2_from_cs1, cs3_from_cs2]).map(point)
     assert str(composite_mapped.system) == "cs3"
@@ -244,12 +244,16 @@ def test_this_one_weird_situation():
     cs2_from_cs1 = create_transform("NullTransform", **{}, dims=(3, 3), systems=("cs1", "cs2"))
     cs3_from_cs2 = create_transform("SRT3DTransform", **PARAMS["SRT3DTransform"], dims=(3, 3), systems=("cs2", "cs3"))
     cs3_from_cs1 = cs3_from_cs2 * cs2_from_cs1
-    assert str(cs3_from_cs1.map(Point([1, 1, 1], "cs1")).system) == "cs3"
+    pt_cs1 = Point([1, 1, 1], "cs1")
+    expected = cs3_from_cs2.map(cs2_from_cs1.map(pt_cs1))
+    assert np.allclose(cs3_from_cs1.map(pt_cs1.coordinates), expected.coordinates)
     assert cs3_from_cs2.full_matrix.shape == (4, 4)  # just used to access it, really
 
     cs1_from_cs0 = create_transform("AffineTransform", **PARAMS["AffineTransform"], dims=(3, 3), systems=("cs0", "cs1"))
     cs3_from_cs0 = cs3_from_cs2 * cs2_from_cs1 * cs1_from_cs0
-    assert str(cs3_from_cs0.map(Point([1, 1, 1], "cs0")).system) == "cs3"
+    pt_cs0 = Point([1, 1, 1], "cs0")
+    expected = cs3_from_cs2.map(cs2_from_cs1.map(cs1_from_cs0.map(pt_cs0)))
+    assert np.allclose(cs3_from_cs0.map(pt_cs0.coordinates), expected.coordinates)
 
 
 @pytest.mark.parametrize("type1", PARAMS.keys())
@@ -260,12 +264,12 @@ def test_copy(type1, inverse1, inverse2):
         cs2_from_cs1 = create_transform(type1, **PARAMS[type1], dims=(3, 3), systems=("cs2", "cs1")).inverse
     else:
         cs2_from_cs1 = create_transform(type1, **PARAMS[type1], dims=(3, 3), systems=("cs1", "cs2"))
-    copy = cs2_from_cs1.copy(from_cs="cs4")
-    assert str(copy.systems[0]) == "cs4"
-    assert str(copy.systems[1]) == "cs2"
-    copy = cs2_from_cs1.copy(to_cs="cs5")
-    assert str(copy.systems[0]) == "cs1"
-    assert str(copy.systems[1]) == "cs5"
+    copy = cs2_from_cs1.copy()
+    assert copy.systems == (None, None)
+    with raises(ValueError):
+        cs2_from_cs1.copy(from_cs="cs4")
+    with raises(ValueError):
+        cs2_from_cs1.copy(to_cs="cs5")
     copy = cs2_from_cs1.copy(from_cs="cs4", to_cs="cs5")
     assert str(copy.systems[0]) == "cs4"
     assert str(copy.systems[1]) == "cs5"
@@ -286,16 +290,16 @@ def test_as_affine_systems(type1):
     xform = create_transform(type1, **PARAMS[type1], dims=(3, 3), systems=("affine1", "affine2"))
     point = Point([1, 2, 3], "affine1")
     with contextlib.suppress(NotImplementedError):  # ignore non-affine transforms here
-        assert np.all(xform.as_affine().map(point) == xform.map(point))
-        assert xform.as_affine().systems == xform.systems
-        assert xform.inverse.as_affine().systems == xform.inverse.systems
-        assert np.allclose(xform.inverse.as_affine().map(xform.map(point)), point)
-        explicitly_looped = xform.inverse.as_affine().map(xform.as_affine().map(point))
-        assert np.allclose(explicitly_looped, point)
+        assert xform.as_affine().systems == (None, None)
+        assert xform.inverse.as_affine().systems == (None, None)
+        assert np.all(xform.as_affine().map(point.coordinates) == xform.map(point).coordinates)
+        assert np.allclose(xform.inverse.as_affine().map(xform.map(point).coordinates), point.coordinates)
+        explicitly_looped = xform.inverse.as_affine().map(xform.as_affine().map(point.coordinates))
+        assert np.allclose(explicitly_looped, point.coordinates)
         mult_loop = xform.inverse * xform
-        assert np.allclose(mult_loop.as_affine().map(point), point)
+        assert np.allclose(mult_loop.as_affine().map(point.coordinates), point.coordinates)
         comp_loop = CompositeTransform([xform, xform.inverse])
-        assert np.allclose(comp_loop.as_affine().map(point), point)
+        assert np.allclose(comp_loop.as_affine().map(point.coordinates), point.coordinates)
 
 
 @pytest.mark.parametrize("type1", PARAMS.keys())
@@ -365,3 +369,156 @@ def test_composite_times_other(type1, inverse1, inverse_composite):
 
     with raises(TypeError):
         CompositeTransform([cs3_from_cs1, cs0_to_cs1])
+
+
+def test_copy_is_systemless():
+    graph = CoordinateSystemGraph.get_graph("copy_sysless_graph", create=True)
+    tr = STTransform(scale=[2, 3], offset=[1, 2], from_cs="A", to_cs="B", cs_graph=graph)
+    copy = tr.copy()
+    assert copy.systems == (None, None)
+    pts = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert np.all(copy.map(pts) == tr.map(pts))
+    assert graph.transform("A", "B") is tr
+    assert set(graph.systems) == {"A", "B"}
+
+
+def test_as_affine_graph_registration():
+    graph = CoordinateSystemGraph.get_graph("as_affine_reg_graph", create=True)
+    tr = STTransform(scale=[2, 3], offset=[1, 2], from_cs="A", to_cs="B", cs_graph=graph)
+    pts = np.array([[1.0, 2.0], [3.0, 4.0]])
+
+    affine = tr.as_affine()
+    assert affine.systems == (None, None)
+    assert np.allclose(affine.map(pts), tr.map(pts))
+    assert graph.transform("A", "B") is tr
+    assert set(graph.systems) == {"A", "B"}
+
+    with raises(ValueError):
+        tr.as_affine(from_cs="A2")
+    with raises(ValueError):
+        tr.as_affine(to_cs="B2")
+
+    affine = tr.as_affine(from_cs="A2", to_cs="B2")
+    assert str(affine.systems[0]) == "A2"
+    assert str(affine.systems[1]) == "B2"
+    assert affine.systems[0].graph is graph
+    assert graph.transform("A2", "B2") is affine
+
+
+def test_copy_graph_registration():
+    graph = CoordinateSystemGraph.get_graph("copy_reg_graph", create=True)
+    tr = STTransform(scale=[2, 3], offset=[1, 2], from_cs="A", to_cs="B", cs_graph=graph)
+
+    copy = tr.copy(system_names="_c1")
+    assert str(copy.systems[0]) == "A_c1"
+    assert str(copy.systems[1]) == "B_c1"
+    assert copy.systems[0].graph is graph
+    assert graph.transform("A_c1", "B_c1") is copy
+
+    copy = tr.copy(system_names={"A": "in2", "B": "out2"})
+    assert str(copy.systems[0]) == "in2"
+    assert str(copy.systems[1]) == "out2"
+    assert graph.transform("in2", "out2") is copy
+
+    copy = tr.copy(from_cs="in3", to_cs="out3")
+    assert str(copy.systems[0]) == "in3"
+    assert str(copy.systems[1]) == "out3"
+    assert graph.transform("in3", "out3") is copy
+
+    with raises(ValueError):
+        tr.copy(system_names={"A": "in4"})
+    with raises(ValueError):
+        tr.copy(from_cs="in4")
+
+    assert graph.transform("A", "B") is tr
+
+
+def test_copy_of_systemless_transform():
+    default_graph = CoordinateSystemGraph.get_graph(None)
+    tr = STTransform(scale=[2, 3], offset=[1, 2])
+    assert tr.systems == (None, None)
+    copy = tr.copy(from_cs="sysless_copy_in", to_cs="sysless_copy_out")
+    assert str(copy.systems[0]) == "sysless_copy_in"
+    assert str(copy.systems[1]) == "sysless_copy_out"
+    assert copy.systems[0].graph is default_graph
+    assert default_graph.transform("sysless_copy_in", "sysless_copy_out") is copy
+
+
+def test_composite_copy_graph_registration():
+    graph = CoordinateSystemGraph.get_graph("comp_copy_graph", create=True)
+    a_to_b = STTransform(scale=[2, 2], offset=[1, 1], from_cs="A", to_cs="B", cs_graph=graph)
+    b_to_c = AffineTransform(matrix=[[0, 1], [1, 0]], offset=[3, 4], from_cs="B", to_cs="C", cs_graph=graph)
+    chain = graph.transform("A", "C")
+    assert isinstance(chain, CompositeTransform)
+    pts = np.array([[1.0, 2.0], [3.0, 4.0]])
+
+    copy = chain.copy()
+    assert all(t.systems == (None, None) for t in copy.transforms)
+    assert np.allclose(copy.map(pts), chain.map(pts))
+    assert graph.transform("A", "B") is a_to_b
+    assert graph.transform("B", "C") is b_to_c
+
+    copy = chain.copy(system_names="_f1")
+    systems = [copy.transforms[0].systems[0]] + [t.systems[1] for t in copy.transforms]
+    assert [str(s) for s in systems] == ["A_f1", "B_f1", "C_f1"]
+    assert np.allclose(copy.map(pts), chain.map(pts))
+    assert graph.transform("A_f1", "B_f1") is copy.transforms[0]
+    assert graph.transform("B_f1", "C_f1") is copy.transforms[1]
+
+    copy = chain.copy(from_cs="A", system_names="_f2")
+    assert copy.transforms[0].systems[0] is graph.system("A")
+    assert str(copy.transforms[0].systems[1]) == "B_f2"
+    assert str(copy.transforms[1].systems[1]) == "C_f2"
+
+    with raises(ValueError):
+        chain.copy(from_cs="A2")
+    with raises(ValueError):
+        chain.copy(system_names={"A": "A3", "C": "C3"})
+
+
+def test_mul_product_is_systemless():
+    graph = CoordinateSystemGraph.get_graph("mul_sysless_graph", create=True)
+    ab = STTransform(scale=[2, 2], offset=[1, 1], from_cs="A", to_cs="B", cs_graph=graph)
+    bc = AffineTransform(matrix=[[0, 1], [1, 0]], offset=[3, 4], from_cs="B", to_cs="C", cs_graph=graph)
+    product = bc * ab
+    assert product.systems == (None, None)
+    pts = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert np.allclose(product.map(pts), bc.map(ab.map(pts)))
+    assert graph.transform("A", "B") is ab
+    assert graph.transform("B", "C") is bc
+    assert set(graph.systems) == {"A", "B", "C"}
+
+
+def test_inverse_derived_transforms_systemless():
+    graph = CoordinateSystemGraph.get_graph("inv_derived_graph", create=True)
+    tr = STTransform(scale=[2, 3], offset=[1, 2], from_cs="A", to_cs="B", cs_graph=graph)
+    pts = np.array([[1.0, 2.0], [3.0, 4.0]])
+
+    inv_affine = tr.inverse.as_affine()
+    assert inv_affine.systems == (None, None)
+    assert np.allclose(inv_affine.map(tr.map(pts)), pts)
+
+    inv_copy = tr.inverse.copy()
+    assert inv_copy.systems == (None, None)
+    assert np.allclose(inv_copy.map(tr.map(pts)), pts)
+
+
+def test_systemless_transform_point_mapping():
+    graph = CoordinateSystemGraph.get_graph("sysless_pt_graph", create=True)
+    tr = STTransform(scale=[2, 3], offset=[1, 2], from_cs="A", to_cs="B", cs_graph=graph)
+    copy = tr.copy()
+    pt = Point([1, 2], graph.system("A"))
+    with raises(TypeError, match=wrong_system):
+        copy.map(pt)
+    assert np.all(copy.map(pt.coordinates) == tr.map(pt).coordinates)
+
+
+def test_save_state_preserves_systems():
+    graph = CoordinateSystemGraph.get_graph("state_systems_graph", create=True)
+    tr = STTransform(scale=[2, 3], offset=[1, 2], from_cs="A", to_cs="B", cs_graph=graph)
+    restored = STTransform.from_state(tr.save_state())
+    assert str(restored.systems[0]) == "A"
+    assert str(restored.systems[1]) == "B"
+    assert restored.systems[0].graph is graph
+    pts = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert np.all(restored.map(pts) == tr.map(pts))


### PR DESCRIPTION
Fixes #17

## Problem

Transforms derived from canonical ones — `as_affine()` results, `copy()`, and optimized `__mul__` products — were constructed with `from_cs=.../to_cs=...`, which registered them in the `CoordinateSystemGraph`. This silently overwrote canonical edges (or added phantom shortcut edges), and the derived transform could then be mutated independently, leaving the graph with two conflicting ways to map between the same systems.

## Approach

A transform either *is* the canonical edge between two systems, or it makes no claims at all: derived transforms have **no coordinate systems by default**, and assigning systems to a copy is opt-in, explicit, and all-or-nothing (no auto-generated names).

- `copy()` returns a system-less copy that never touches the graph. `copy(from_cs=..., to_cs=..., system_names=<dict or suffix>)` resolves names for **all** of the copy's systems (`ValueError` if any are unresolvable) and registers the copy canonically. `CompositeTransform.copy()` resolves the full chain and registers each sub-copy, so a whole path can be frozen as new edges:
  ```python
  graph.transform('A', 'C').copy(system_names='_frame12')  # A_frame12 -> B_frame12 -> C_frame12
  ```
- `as_affine()` returns a system-less affine via a new `_as_affine()` subclass hook; `as_affine(from_cs=..., to_cs=...)` assigns systems to the result:
  ```python
  graph.transform('global', camera.system).as_affine(from_cs='global', to_cs='camera_frame_12')
  ```
- `__mul__`/`__rmul__` products and `as_st()` are system-less. A `None` system acts as a wildcard in `validate_transform_for_mul` and composite chain validation, so derived transforms compose with canonical ones (this also keeps `simplified` working).
- Deleted the redundant `AffineTransform.copy` override; `InverseTransform.copy/as_affine` follow the same rules. Serialization (`save_state`/`__setstate__`) is unchanged and still preserves systems.
- Consequence, now documented by test: mapping a `Point` through a system-less transform raises `TypeError` (the transform makes no claims about systems); raw arrays map fine.

## Deferred (discussed in #17)

- `SimplifiedCompositeTransform` redesign (possibly removal)
- flipping `unique_transforms=True` by default (needs a `remove_transform`/replace API first)

## Testing

- Rewrote four tests in `test_systems.py` that encoded the old semantics (derived transforms inheriting systems).
- Nine new tests: copy/as_affine graph hygiene, naming variants and error cases, composite chain freezing, system-less products, inverse-derived transforms, Point mapping behavior, and a serialization regression guard.
- Full suite: 540 passed; the only failure (`test_image.ipynb` rendered-image pixel dimensions) is pre-existing and unrelated (verified against stashed sources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)